### PR TITLE
[Fix][QuestaoViewController] - Corrige Botões de Respostas

### DIFF
--- a/iQuiz/iQuiz/ViewController/QuestaoViewController.swift
+++ b/iQuiz/iQuiz/ViewController/QuestaoViewController.swift
@@ -48,9 +48,11 @@ class QuestaoViewController: UIViewController {
     @objc func configurarQuestao() {
         tituloQuestaoLabel.text = questoes[numeroQuestao].titulo
         for botao in botoesResposta {
+            botao.isEnabled = true
             botao.backgroundColor = UIColor(red: 116/255, green: 58/255, blue: 255/255, alpha: 1.0)
             let tituloBotao = questoes[numeroQuestao].respostas[botao.tag]
             botao.setTitle(tituloBotao, for: .normal)
+            botao.addTarget(self, action: #selector(bloquearRespostas), for: .touchDown)
         }
     }
 
@@ -65,9 +67,7 @@ class QuestaoViewController: UIViewController {
         tituloQuestaoLabel.textAlignment = .center
         navigationItem.hidesBackButton = true
         for botao in botoesResposta {
-            botao.isEnabled = true
             botao.layer.cornerRadius = 12.0
-            botao.addTarget(self, action: #selector(bloquearRespostas), for: .touchDown)
         }
     }
     

--- a/iQuiz/iQuiz/ViewController/QuestaoViewController.swift
+++ b/iQuiz/iQuiz/ViewController/QuestaoViewController.swift
@@ -53,13 +53,21 @@ class QuestaoViewController: UIViewController {
             botao.setTitle(tituloBotao, for: .normal)
         }
     }
+
+    @objc func bloquearRespostas() {
+        for botao in botoesResposta {
+            botao.isEnabled = false
+        }
+    }
     
     func configurarLayout() {
         tituloQuestaoLabel.numberOfLines = 0
         tituloQuestaoLabel.textAlignment = .center
         navigationItem.hidesBackButton = true
         for botao in botoesResposta {
+            botao.isEnabled = true
             botao.layer.cornerRadius = 12.0
+            botao.addTarget(self, action: #selector(bloquearRespostas), for: .touchDown)
         }
     }
     


### PR DESCRIPTION
Ao fazer o curso de Swift na Alura, desenvolvemos o aplicativo iQuiz. Durante as aulas onde fizemos a QuestaoViewController, aumentei o tempo de duração entre as respostas para fazer testes e percebi que mesmo após clicar em alguma resposta (seja ela a certa ou a errada), eu conseguia clicar nas demais opções de respostas também, alterando a cor dos botões (vermelho para incorreta, verde para a correta).

- Implementei uma ```@objc``` chamada ```bloquearRespostas``` para bloquear todos os botões de respostas sempre que um Evento de toque for acionado em algum dos botões.
- Forcei o a propriedade ```isEnabled``` dos botões ser veradeira ao configurarmos as questões no método ```configurarQuestao```, para "resetar" os botões.

@giovannamoeller por favor, poderia revisar esse PR e me dizer se haveria alguma forma melhor de corrigir esse problema?